### PR TITLE
Fix "Success" URL for Github Enterprise

### DIFF
--- a/build/gist
+++ b/build/gist
@@ -1645,7 +1645,7 @@ module Gist
 
       if Net::HTTPCreated === response
         AuthTokenFile.write JSON.parse(response.body)['token']
-        puts "Success! #{ENV[URL_ENV_NAME] || "https://github.com/"}settings/applications"
+        puts "Success! #{ENV[URL_ENV_NAME] || "https://github.com"}/settings/applications"
         return
       elsif Net::HTTPUnauthorized === response
         puts "Error: #{JSON.parse(response.body)['message']}"


### PR DESCRIPTION
# Error

The URL is print as follows:

Success! https://github.company.comsettings/applications

It should be 

Success! https://github.company.com/settings/applications
# Steps to Reproduce

```
mdesales@Marcello-New2015 [09/28/201611:33:20] ~ $ export GITHUB_URL=https://github.company.com
mdesales@Marcello-New2015 [09/28/201611:34:42] ~ $ gist --login
Obtaining OAuth2 access_token from github.
GitHub username: marcellodesales
GitHub password:
Success! https://github.company.comsettings/applications
```
# Proposed fix

Just remove the "/" from the default github.com URL and place it in the proper place.
